### PR TITLE
Fix output of "-s devices" when a zpool is specified

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -171,7 +171,7 @@ usage(char * app_name) {
 			"\treal\t\t- print real used space after dedup\n"
 			"\tavailable\t- print available space\n\n"
 			"\tpools\t\t- print pools\n"
-	        "\tdevices\t\t- print devices in zpool\n"
+	        "\tdevices\t\t- print devices in zpool (or in all pools)\n"
 			"\tdevice-state\t- print state of device\n"
 			"\tddt-memory\t- print size of deduplication table in memory\n"
 			"\tstatus\t\t- print status message of pool\n");

--- a/src/vdev_status.c
+++ b/src/vdev_status.c
@@ -233,7 +233,7 @@ zpool_print_vdev(zpool_handle_t * zhp, void * data) {
         (void) fprintf(stderr, "   see: http://zfsonlinux.org/msg/%s\n", msgId);
     */
 
-    if (config != NULL) {
+    if (strcmp(zpool_get_name(zhp), zstat->name) == 0 || zstat->name[0] == '\0') {
         nvlist_t ** spares;
         uint_t nspares;
         pool_scan_stat_t * ps = NULL;


### PR DESCRIPTION
Hello,

When using syntax like this `zio -s devices -f text -z rpool`, the output includes devices from all pools on the system. This pull request adds a small check to ensure that only devices in the specified pool are shown. 

Before:
```
% ./zio -f text -s devices -z rpool
c2t3d0
c2t2d0
c2t0d0
c2t1d0
c4t1d0s0
```

After:
```
% ./zio -f text -s devices -z rpool
c4t1d0s0
```

```
% zpool status rpool
  pool: rpool
 state: ONLINE
  scan: none requested
config:

        NAME        STATE     READ WRITE CKSUM
        rpool       ONLINE       0     0     0
          c4t1d0s0  ONLINE       0     0     0

```

Tested on OmniOS. Unfortunately I do not have any Linux systems to test with.