### PR TITLE
Solaris does not require root permissions to run

### DIFF
--- a/src/zio.c
+++ b/src/zio.c
@@ -85,12 +85,14 @@ main(int argc, char *argv[]) {
 	config_t cnf;
 	zstatus_t zstat;
 
+#if !defined(SOLARIS)
     if(geteuid() != 0)
     {
         // Tell user to run app as root, then exit.
         fprintf(stderr, "you have to run %s as root\n", argv[0]);
         exit(1);
     }
+#endif
 
 
     cnf.zname[0] = '\0';


### PR DESCRIPTION
Solaris (tested on OmniOS) does not require root permissions to view zpool/zfs stats. This is true with the zpool(1M) and zfs(1M) commands and also with zio.