### PR TITLE
Fix compilation with modern versions of ZFS

### DIFF
--- a/src/memlist.c
+++ b/src/memlist.c
@@ -40,7 +40,7 @@ add_to_devlist(devlist_t * d, const char * device, const char * state, const cha
 
     strcpy(d->device, device);
     strcpy(d->state, state);
-    strncpy(d->pool, pool, ZPOOL_MAXNAMELEN);
+    strncpy(d->pool, pool, ZFS_MAX_DATASET_NAME_LEN);
     d->message = message;
 
     return 0;

--- a/src/memlist.h
+++ b/src/memlist.h
@@ -19,7 +19,7 @@ struct devlist {
     char * device;
     char * state;
     const char * message;
-    char pool[ZPOOL_MAXNAMELEN];
+    char pool[iZFS_MAX_DATASET_NAME_LEN];
 
     devlist_t * next;
 };


### PR DESCRIPTION
illumos/illumos-gate@9adfa60 renamed the ZFS_MAXNAMELEN define to
ZFS_MAX_DATASET_NAMELEN. This enables zio to compile again on FreeBSD 11
and OmniOS(CE) r151022